### PR TITLE
Build with golang:1.18-alpine3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine3.13 as builder-base
+FROM golang:1.18-alpine3.16 as builder-base
 
 ARG DRONE_VERSION_TAG=v2.13.0
 ARG BUILD_TAGS=
@@ -25,7 +25,7 @@ RUN GOOS=linux GOARCH=amd64 go build \
 #
 # the only difference is the binary of `drone-server`
 #
-FROM alpine:3.13 as base
+FROM alpine:3.16 as base
 
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Key Differences
 
-- Build with Go 1.14, Alpine 3.13
+- Build with golang:1.18-alpine3.16
 - Build with tags (nolimit, oss)
 - Optimized Docker images
 
@@ -14,9 +14,9 @@
 $ docker image ls
 
 REPOSITORY    TAG                 SIZE
-guessi/drone  2.13.0-nolimit-oss  39.4MB # DroneCI Server Image build with `--tags "nolimit oss"`
-guessi/drone  2.13.0-nolimit      58.6MB # DroneCI Server Image build with `--tags "nolimit"`
-guessi/drone  2.13.0              58.7MB # DroneCI Server Image build without `--tags`
+guessi/drone  2.13.0-nolimit-oss  35.8MB # DroneCI Server Image build with `--tags "nolimit oss"`
+guessi/drone  2.13.0-nolimit      52.1MB # DroneCI Server Image build with `--tags "nolimit"`
+guessi/drone  2.13.0              52.1MB # DroneCI Server Image build without `--tags`
 drone/drone   2.13.0-linux-amd64  60.4MB # DroneCI Server Official Image
 ```
 


### PR DESCRIPTION
Not sure why upstream mixed multiple EOL-golang ang EOL-alpine versions altogether 🤔 

## drone
* https://github.com/harness/drone/blob/master/docker/Dockerfile.server.linux.amd64 -> alpine3.11 ⚠️ 
* https://github.com/harness/drone/blob/master/BUILDING_OSS -> go1.11 ⚠️ 
* https://github.com/harness/drone/blob/master/go.mod#L63 -> go1.13 ⚠️ 
* https://github.com/harness/drone/blob/master/.drone.yml -> go1.14 ⚠️ 

## drone-cli
* https://github.com/harness/drone-cli/blob/master/go.mod#L3 -> go1.18
* https://github.com/harness/drone-cli/blob/master/Dockerfile -> https://github.com/drone/ca-certs/blob/master/Dockerfile -> alpine 3.6 ⚠️ 

## drone-go
* https://github.com/drone/drone-go/blob/master/go.mod#L3 -> go1.14 ⚠️ 
* https://github.com/drone/drone-go/blob/master/.drone.yml -> go1.15 ⚠️ 

## runner-go
* https://github.com/drone/runner-go/blob/master/go.mod -> go1.12 ⚠️ 
* https://github.com/drone/runner-go/blob/master/.drone.yml -> go1.12 ⚠️ 

## drong-git
* https://github.com/drone/drone-git/blob/master/.drone.yml -> go1.10 ⚠️ 
* https://github.com/drone/drone-git/blob/master/docker/Dockerfile.linux.amd64 -> alpine3.12 ⚠️ 

## autoscaler
* https://github.com/drone/autoscaler/blob/master/.drone.yml -> go:latest
* https://github.com/drone/autoscaler/blob/master/Dockerfile -> alpine3.6 ⚠️ 